### PR TITLE
Throws exception from OAuth2SsoConfigurerAdapter.configure

### DIFF
--- a/src/main/java/org/springframework/cloud/security/sso/OAuth2SsoConfigurerAdapter.java
+++ b/src/main/java/org/springframework/cloud/security/sso/OAuth2SsoConfigurerAdapter.java
@@ -24,7 +24,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 public class OAuth2SsoConfigurerAdapter implements OAuth2SsoConfigurer {
 
 	@Override
-	public void configure(HttpSecurity http) {
+	public void configure(HttpSecurity http) throws Exception {
 	}
 
 }


### PR DESCRIPTION
OAuth2SsoConfigurerAdapter extends from OAuth2SsoConfigurer. The interface includes Exception in its throws clause; however, that is not in the adapter implementation. Other Spring classes utilizing this pattern do declare the thrown exception; e.g., see WebSecurityConfigurerAdapter.

SAS Institute, Inc. has signed and agreed to the terms of the SpringSource Corporate Contributor License Agreement.
