### PR TITLE
Enhance token requests with a Basic auth header

### DIFF
--- a/src/main/java/org/springframework/cloud/security/oauth2/ClientConfiguration.java
+++ b/src/main/java/org/springframework/cloud/security/oauth2/ClientConfiguration.java
@@ -105,6 +105,8 @@ public class ClientConfiguration {
 					OAuth2ProtectedResourceDetails resource,
 					MultiValueMap<String, String> form, HttpHeaders headers) {
 				headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+				String authHeader = resource.getClientId() + ":" + resource.getClientSecret();
+				headers.add("Authorization", "Basic " + DatatypeConverter.printBase64Binary(authHeader.getBytes()));
 			}
 		});
 		template.setAccessTokenProvider(accessTokenProvider);


### PR DESCRIPTION
CF UAA seems to require the Basic authorization header.  As per the spec, the authorization server must support Basic authentication for the client credentials, and MAY support the client_secret parameter: http://tools.ietf.org/html/rfc6749#section-2.3.1

This is to address: https://github.com/spring-cloud/spring-cloud-security/issues/11
