### PR TITLE
Only set fallback SSO matcher if no configurers exist

### DIFF
--- a/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfiguration.java
@@ -142,8 +142,6 @@ public class OAuth2SsoConfiguration extends WebSecurityConfigurerAdapter impleme
 		if (!sso.getHome().isSecure()) {
 			requests.antMatchers(sso.getHome().getPath()).permitAll();
 		}
-		// Fallback to authenticated for everything
-		requests.anyRequest().authenticated();
 
 		LogoutConfigurer<HttpSecurity> logout = http.logout();
 		logout.logoutSuccessUrl(sso.getHome().getRoot())
@@ -159,6 +157,9 @@ public class OAuth2SsoConfiguration extends WebSecurityConfigurerAdapter impleme
 			// exception handling provided here will override those above.
 			configurer.configure(http);
 		}
+
+		// Fallback to authenticated for everything
+		requests.anyRequest().authenticated();
 	}
 
 	private void addRedirectToLogout(LogoutConfigurer<HttpSecurity> logout) {

--- a/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfiguration.java
@@ -158,8 +158,12 @@ public class OAuth2SsoConfiguration extends WebSecurityConfigurerAdapter impleme
 			configurer.configure(http);
 		}
 
-		// Fallback to authenticated for everything
-		requests.anyRequest().authenticated();
+		// Fallback to authenticated for everything.
+		// Spring security only accepts one anyRequest() matcher
+		// so only set it if the user hasn't registered any configurers
+		if(configurers.isEmpty()) {
+			requests.anyRequest().authenticated();
+		}
 	}
 
 	private void addRedirectToLogout(LogoutConfigurer<HttpSecurity> logout) {

--- a/src/test/java/org/springframework/cloud/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
+++ b/src/test/java/org/springframework/cloud/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
@@ -96,7 +96,9 @@ public class CustomOAuth2SsoConfigurationTests {
 
 		@Override
 		public void configure(HttpSecurity http) throws Exception {
-			http.authorizeRequests().antMatchers("/ui/test").permitAll();
+			http.authorizeRequests()
+					.antMatchers("/ui/test").permitAll()
+					.anyRequest().authenticated();
 		}
 
 		@Override

--- a/src/test/java/org/springframework/cloud/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
+++ b/src/test/java/org/springframework/cloud/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.security.oauth2.sso;
 
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -31,11 +32,15 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.security.oauth2.sso.CustomOAuth2SsoConfigurationTests.TestConfiguration;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.stereotype.Controller;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -78,13 +83,35 @@ public class CustomOAuth2SsoConfigurationTests {
 				.andExpect(header().string("location", "http://localhost/login"));
 	}
 
+	@Test
+	public void uiTestPageIsAccessible() throws Exception {
+		mvc.perform(get("/ui/test")).andExpect(status().isOk())
+				.andExpect(content().string("test"));
+	}
+
 	@Configuration
 	@EnableOAuth2Sso
 	@EnableAutoConfiguration
 	protected static class TestConfiguration extends OAuth2SsoConfigurerAdapter {
+
+		@Override
+		public void configure(HttpSecurity http) throws Exception {
+			http.authorizeRequests().antMatchers("/ui/test").permitAll();
+		}
+
 		@Override
 		public void match(RequestMatchers matchers) {
 			matchers.antMatchers("/ui/**");
+		}
+
+		@RestController
+		public static class TestController {
+
+			@RequestMapping(value = "/ui/test")
+			public String test() {
+				return "test";
+			}
+
 		}
 	}
 

--- a/src/test/java/org/springframework/cloud/security/oauth2/sso/ExceptionHandlingOAuth2SsoConfigurationTests.java
+++ b/src/test/java/org/springframework/cloud/security/oauth2/sso/ExceptionHandlingOAuth2SsoConfigurationTests.java
@@ -85,8 +85,9 @@ public class ExceptionHandlingOAuth2SsoConfigurationTests {
 
 		@Override
 		public void configure(HttpSecurity http) throws Exception {
-			http.exceptionHandling().authenticationEntryPoint(
-					new Http401AuthenticationEntryPoint("Session realm=\"JSESSIONID\""));
+			http.authorizeRequests().anyRequest().authenticated().and()
+					.exceptionHandling().authenticationEntryPoint(
+						new Http401AuthenticationEntryPoint("Session realm=\"JSESSIONID\""));
 		}
 	}
 


### PR DESCRIPTION
As discussed in #36.

If the fallback matcher gets set when the user has already registered an `anyRequest()` matcher, it will override the user's settings, so this adds a check to determine if the user has registered any configurers before setting the fallback.