### PR TITLE
Custom Feign RequestInterceptor for Spring OAuth2

### DIFF
--- a/spring-cloud-security/pom.xml
+++ b/spring-cloud-security/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-security</artifactId>
@@ -50,11 +50,11 @@
 			<artifactId>spring-cloud-config-server</artifactId>
 			<optional>true</optional>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-feign</artifactId>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-feign</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-netflix-core</artifactId>

--- a/spring-cloud-security/pom.xml
+++ b/spring-cloud-security/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-security</artifactId>
@@ -50,6 +50,11 @@
 			<artifactId>spring-cloud-config-server</artifactId>
 			<optional>true</optional>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-feign</artifactId>
+            <optional>true</optional>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-netflix-core</artifactId>

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
@@ -16,12 +16,25 @@
 
 package org.springframework.cloud.security.oauth2.client.feign;
 
+import java.util.Arrays;
+
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.security.oauth2.client.http.AccessTokenRequiredException;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.resource.UserRedirectRequiredException;
+import org.springframework.security.oauth2.client.token.AccessTokenProvider;
+import org.springframework.security.oauth2.client.token.AccessTokenProviderChain;
 import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsAccessTokenProvider;
+import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeAccessTokenProvider;
+import org.springframework.security.oauth2.client.token.grant.implicit.ImplicitAccessTokenProvider;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordAccessTokenProvider;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
 
 /**
  * Pre-defined custom RequestInterceptor for Feign Requests
@@ -32,76 +45,127 @@ import org.springframework.security.oauth2.client.token.AccessTokenRequest;
  */
 public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
 
-    public static final String BEARER = "Bearer";
+	public static final String BEARER = "Bearer";
 
-    public static final String AUTHORIZATION = "Authorization";
+	public static final String AUTHORIZATION = "Authorization";
 
-    private final Logger logger = LoggerFactory.getLogger(OAuth2FeignRequestInterceptor.class);
+	private static final Logger logger = LoggerFactory.getLogger(OAuth2FeignRequestInterceptor.class);
 
-    private final OAuth2ClientContext oAuth2ClientContext;
+	private final OAuth2ClientContext oAuth2ClientContext;
 
-    private final String tokenType;
+	private final OAuth2ProtectedResourceDetails resource;
 
-    private final String header;
+	private final String tokenType;
 
-    /**
-     * Default constructor which uses the provided OAuth2ClientContext and
-     * Bearer tokens within Authorization header
-     *
-     * @param oAuth2ClientContext provided context
-     */
-    public OAuth2FeignRequestInterceptor(OAuth2ClientContext oAuth2ClientContext) {
-        this(oAuth2ClientContext, BEARER, AUTHORIZATION);
-        logger.debug("Constructing default OAuth2FeignRequestInterceptor");
-    }
+	private final String header;
 
-    /**
-     * Fully customizable constructor for changing token type and header name, in cases of Bearer and Authorization is not the default
-     * such as "bearer", "authorization"
-     *
-     * @param oAuth2ClientContext current oAuth2 Context
-     * @param tokenType           type of token e.g. "token", "Bearer"
-     * @param header              name of the header e.g. "Authorization", "authorization"
-     */
-    public OAuth2FeignRequestInterceptor(OAuth2ClientContext oAuth2ClientContext, String tokenType, String header) {
-        this.oAuth2ClientContext = oAuth2ClientContext;
-        this.tokenType = tokenType;
-        this.header = header;
-    }
+	private AccessTokenProvider accessTokenProvider = new AccessTokenProviderChain(Arrays.<AccessTokenProvider>asList(
+			new AuthorizationCodeAccessTokenProvider(), new ImplicitAccessTokenProvider(),
+			new ResourceOwnerPasswordAccessTokenProvider(), new ClientCredentialsAccessTokenProvider()));
 
-    private static boolean tokenExists(OAuth2ClientContext oAuth2ClientContext) {
-        return oAuth2ClientContext.getAccessTokenRequest().getExistingToken() != null;
-    }
+	/**
+	 * Default constructor which uses the provided OAuth2ClientContext and
+	 * Bearer tokens within Authorization header
+	 *
+	 * @param oAuth2ClientContext provided context
+	 * @param resource            type of resource to be accessed
+	 */
+	public OAuth2FeignRequestInterceptor(OAuth2ClientContext oAuth2ClientContext, OAuth2ProtectedResourceDetails resource) {
+		this(oAuth2ClientContext, resource, BEARER, AUTHORIZATION);
+	}
 
-    /**
-     * Create a template with the header of provided name and extracted value
-     *
-     * @see RequestInterceptor#apply(RequestTemplate)
-     */
-    @Override
-    public void apply(RequestTemplate template) {
-        if (tokenExists(oAuth2ClientContext)) {
-            logger.debug("Applying RequestInterceptor customization");
-            template.header(header, value(tokenType));
-        }
-    }
+	/**
+	 * Fully customizable constructor for changing token type and header name, in cases of Bearer and Authorization is not the default
+	 * such as "bearer", "authorization"
+	 *
+	 * @param oAuth2ClientContext current oAuth2 Context
+	 * @param resource            type of resource to be accessed
+	 * @param tokenType           type of token e.g. "token", "Bearer"
+	 * @param header              name of the header e.g. "Authorization", "authorization"
+	 */
+	public OAuth2FeignRequestInterceptor(OAuth2ClientContext oAuth2ClientContext, OAuth2ProtectedResourceDetails resource, String tokenType, String header) {
+		this.oAuth2ClientContext = oAuth2ClientContext;
+		this.resource = resource;
+		this.tokenType = tokenType;
+		this.header = header;
+	}
 
-    /**
-     * Extracts the token value id the access token exists or returning an empty value if there is no one on the context
-     * it may occasionally causes Unauthorized response since the token value is empty
-     *
-     * @param tokenType type name of token
-     * @return extracted value from context if it exists otherwise empty String
-     */
-    protected String value(String tokenType) {
-        final AccessTokenRequest accessTokenRequest = oAuth2ClientContext.getAccessTokenRequest();
-        if (accessTokenRequest.getExistingToken() != null) {
-            logger.debug("Returning token {} value", tokenType);
-            return String.format("%s %s", tokenType, accessTokenRequest.getExistingToken().toString());
-        }
-        logger.debug("No accessTokenRequest found for Feign RequestTemplate!");
-        return "";
-    }
+	/**
+	 * Create a template with the header of provided name and extracted extract
+	 *
+	 * @see RequestInterceptor#apply(RequestTemplate)
+	 */
+	@Override
+	public void apply(RequestTemplate template) {
+		template.header(header, extract(tokenType));
+	}
 
+	/**
+	 * Extracts the token extract id the access token exists or returning an empty extract if there is no one on the context
+	 * it may occasionally causes Unauthorized response since the token extract is empty
+	 *
+	 * @param tokenType type name of token
+	 * @return token value from context if it exists otherwise empty String
+	 */
+	protected String extract(String tokenType) {
+		OAuth2AccessToken accessToken = getToken();
+		return String.format("%s %s", tokenType, accessToken.getValue());
+	}
 
+	/**
+	 * Extract the access token within the request or try to acquire a new one by delegating it to {@link #acquireAccessToken()}
+	 *
+	 * @return valid token
+	 */
+	public OAuth2AccessToken getToken() {
+
+		OAuth2AccessToken accessToken = oAuth2ClientContext.getAccessToken();
+		if (accessToken == null || accessToken.isExpired()) {
+			try {
+				accessToken = acquireAccessToken();
+			}
+			catch (UserRedirectRequiredException e) {
+				oAuth2ClientContext.setAccessToken(null);
+				String stateKey = e.getStateKey();
+				if (stateKey != null) {
+					Object stateToPreserve = e.getStateToPreserve();
+					if (stateToPreserve == null) {
+						stateToPreserve = "NONE";
+					}
+					oAuth2ClientContext.setPreservedState(stateKey, stateToPreserve);
+				}
+				throw e;
+			}
+		}
+		return accessToken;
+	}
+
+	/**
+	 * Try to acquire the token using a access token provider
+	 *
+	 * @throws UserRedirectRequiredException in case the user needs to be redirected to an approval page or login page
+	 * @return valid access token
+	 */
+	protected OAuth2AccessToken acquireAccessToken() throws UserRedirectRequiredException {
+		AccessTokenRequest tokenRequest = oAuth2ClientContext.getAccessTokenRequest();
+		if (tokenRequest == null) {
+			throw new AccessTokenRequiredException(
+					"Cannot find valid context on request for resource '" + resource.getId() + "'.", resource);
+		}
+		String stateKey = tokenRequest.getStateKey();
+		if (stateKey != null) {
+			tokenRequest.setPreservedState(oAuth2ClientContext.removePreservedState(stateKey));
+		}
+		OAuth2AccessToken existingToken = oAuth2ClientContext.getAccessToken();
+		if (existingToken != null) {
+			oAuth2ClientContext.setAccessToken(existingToken);
+		}
+		OAuth2AccessToken obtainableAccessToken;
+		obtainableAccessToken = accessTokenProvider.obtainAccessToken(resource, tokenRequest);
+		if (obtainableAccessToken == null || obtainableAccessToken.getValue() == null) {
+			throw new IllegalStateException(" Access token provider returned a null token, which is illegal according to the contract.");
+		}
+		oAuth2ClientContext.setAccessToken(obtainableAccessToken);
+		return obtainableAccessToken;
+	}
 }

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
@@ -32,6 +32,7 @@ import org.springframework.security.oauth2.client.token.AccessTokenRequest;
 public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
 
     public static final String BEARER = "Bearer";
+
     public static final String AUTHORIZATION = "Authorization";
 
     private final Logger logger = LoggerFactory.getLogger(OAuth2FeignRequestInterceptor.class);

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
@@ -1,18 +1,19 @@
 /*
- *        Copyright 2015 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.springframework.cloud.security.oauth2.client.feign;
 
 import feign.RequestInterceptor;

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
@@ -1,0 +1,105 @@
+/*
+ *        Copyright 2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.springframework.cloud.security.oauth2.client.feign;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+
+/**
+ * Pre-defined custom RequestInterceptor for Feign Requests
+ * It uses the {@link OAuth2ClientContext OAuth2ClientContext} provided from the environment
+ * and construct a new header on the request before it is made by Feign
+ *
+ * @author Joao Pedro Evangelista
+ */
+public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+    public static final String BEARER = "Bearer";
+    public static final String AUTHORIZATION = "Authorization";
+
+    private final Logger logger = LoggerFactory.getLogger(OAuth2FeignRequestInterceptor.class);
+
+    private final OAuth2ClientContext oAuth2ClientContext;
+
+    private final String tokenType;
+
+    private final String header;
+
+    /**
+     * Default constructor which uses the provided OAuth2ClientContext and
+     * Bearer tokens within Authorization header
+     *
+     * @param oAuth2ClientContext provided context
+     */
+    public OAuth2FeignRequestInterceptor(OAuth2ClientContext oAuth2ClientContext) {
+        this(oAuth2ClientContext, BEARER, AUTHORIZATION);
+        logger.debug("Constructing default OAuth2FeignRequestInterceptor");
+    }
+
+    /**
+     * Fully customizable constructor for changing token type and header name, in cases of Bearer and Authorization is not the default
+     * such as "bearer", "authorization"
+     *
+     * @param oAuth2ClientContext current oAuth2 Context
+     * @param tokenType           type of token e.g. "token", "Bearer"
+     * @param header              name of the header e.g. "Authorization", "authorization"
+     */
+    public OAuth2FeignRequestInterceptor(OAuth2ClientContext oAuth2ClientContext, String tokenType, String header) {
+        this.oAuth2ClientContext = oAuth2ClientContext;
+        this.tokenType = tokenType;
+        this.header = header;
+    }
+
+    private static boolean tokenExists(OAuth2ClientContext oAuth2ClientContext) {
+        return oAuth2ClientContext.getAccessTokenRequest().getExistingToken() != null;
+    }
+
+    /**
+     * Create a template with the header of provided name and extracted value
+     *
+     * @see RequestInterceptor#apply(RequestTemplate)
+     */
+    @Override
+    public void apply(RequestTemplate template) {
+        if (tokenExists(oAuth2ClientContext)) {
+            logger.debug("Applying RequestInterceptor customization");
+            template.header(header, value(tokenType));
+        }
+    }
+
+    /**
+     * Extracts the token value id the access token exists or returning an empty value if there is no one on the context
+     * it may occasionally causes Unauthorized response since the token value is empty
+     *
+     * @param tokenType type name of token
+     * @return extracted value from context if it exists otherwise empty String
+     */
+    protected String value(String tokenType) {
+        final AccessTokenRequest accessTokenRequest = oAuth2ClientContext.getAccessTokenRequest();
+        if (accessTokenRequest.getExistingToken() != null) {
+            logger.debug("Returning token {} value", tokenType);
+            return String.format("%s %s", tokenType, accessTokenRequest.getExistingToken().toString());
+        }
+        logger.debug("No accessTokenRequest found for Feign RequestTemplate!");
+        return "";
+    }
+
+
+}

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/MockOAuth2ClientContext.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/MockOAuth2ClientContext.java
@@ -1,0 +1,50 @@
+package org.springframework.cloud.security.oauth2.client.feign;
+
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+import org.springframework.security.oauth2.client.token.DefaultAccessTokenRequest;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+
+import java.util.HashMap;
+
+/**
+ * Mocks the current client context
+ *
+ * @author João Pedro Evangelista
+ */
+final class MockOAuth2ClientContext implements OAuth2ClientContext {
+
+    private final String value;
+
+    public MockOAuth2ClientContext(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public OAuth2AccessToken getAccessToken() {
+        return new DefaultOAuth2AccessToken(value);
+    }
+
+    @Override
+    public void setAccessToken(OAuth2AccessToken accessToken) {
+
+    }
+
+    @Override
+    public AccessTokenRequest getAccessTokenRequest() {
+        DefaultAccessTokenRequest tokenRequest = new DefaultAccessTokenRequest(new HashMap<String, String[]>());
+        tokenRequest.setExistingToken(new DefaultOAuth2AccessToken(value));
+        return tokenRequest;
+    }
+
+    @Override
+    public void setPreservedState(String stateKey, Object preservedState) {
+
+    }
+
+    @Override
+    public Object removePreservedState(String stateKey) {
+        return null;
+    }
+}

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/MockOAuth2ClientContext.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/MockOAuth2ClientContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.security.oauth2.client.feign;
 
 import org.springframework.security.oauth2.client.OAuth2ClientContext;

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.contains;
 public class OAuth2FeignRequestInterceptorTests {
 
     private OAuth2FeignRequestInterceptor oAuth2FeignRequestInterceptor;
+
     private RequestTemplate requestTemplate;
 
     @Before

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
@@ -16,37 +16,49 @@
 
 package org.springframework.cloud.security.oauth2.client.feign;
 
+import static org.hamcrest.Matchers.*;
+
+import java.util.Collection;
+import java.util.Map;
+
 import feign.RequestTemplate;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collection;
-import java.util.Map;
-
-import static org.hamcrest.Matchers.contains;
+import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
+import org.springframework.security.oauth2.client.resource.BaseOAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
 
 /**
  * @author João Pedro Evangelista
  */
 public class OAuth2FeignRequestInterceptorTests {
 
-    private OAuth2FeignRequestInterceptor oAuth2FeignRequestInterceptor;
+	private OAuth2FeignRequestInterceptor oAuth2FeignRequestInterceptor;
 
-    private RequestTemplate requestTemplate;
+	private RequestTemplate requestTemplate;
 
-    @Before
-    public void setUp() throws Exception {
-        oAuth2FeignRequestInterceptor = new OAuth2FeignRequestInterceptor(new MockOAuth2ClientContext("Fancy"));
-        requestTemplate = new RequestTemplate().method("GET");
-    }
+	@Before
+	public void setUp() throws Exception {
+		oAuth2FeignRequestInterceptor = new OAuth2FeignRequestInterceptor(new MockOAuth2ClientContext("Fancy"), new BaseOAuth2ProtectedResourceDetails());
+		requestTemplate = new RequestTemplate().method("GET");
+	}
 
-    @Test
-    public void applyAuthorizationHeader() throws Exception {
-        oAuth2FeignRequestInterceptor.apply(requestTemplate);
-        System.out.println(requestTemplate);
-        Map<String, Collection<String>> headers = requestTemplate.headers();
-        Assert.assertTrue("RequestTemplate must have a Authorization header", headers.containsKey("Authorization"));
-        Assert.assertThat("Authorization must have a value of Fancy", headers.get("Authorization"), contains("Bearer Fancy"));
-    }
+	@Test
+	public void applyAuthorizationHeader() throws Exception {
+		oAuth2FeignRequestInterceptor.apply(requestTemplate);
+		System.out.println(requestTemplate);
+		Map<String, Collection<String>> headers = requestTemplate.headers();
+		Assert.assertTrue("RequestTemplate must have a Authorization header", headers.containsKey("Authorization"));
+		Assert.assertThat("Authorization must have a extract of Fancy", headers.get("Authorization"), contains("Bearer Fancy"));
+	}
+
+	@Test(expected = OAuth2AccessDeniedException.class)
+	public void tryToAcquireToken() {
+		oAuth2FeignRequestInterceptor = new OAuth2FeignRequestInterceptor(new DefaultOAuth2ClientContext(), new BaseOAuth2ProtectedResourceDetails());
+		OAuth2AccessToken oAuth2AccessToken = oAuth2FeignRequestInterceptor.getToken();
+		Assert.assertTrue(oAuth2AccessToken.getValue() + " Must be null", oAuth2AccessToken.getValue() == null);
+	}
 }

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
@@ -1,0 +1,35 @@
+package org.springframework.cloud.security.oauth2.client.feign;
+
+import feign.RequestTemplate;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.contains;
+
+/**
+ * @author João Pedro Evangelista
+ */
+public class OAuth2FeignRequestInterceptorTests {
+
+    private OAuth2FeignRequestInterceptor oAuth2FeignRequestInterceptor;
+    private RequestTemplate requestTemplate;
+
+    @Before
+    public void setUp() throws Exception {
+        oAuth2FeignRequestInterceptor = new OAuth2FeignRequestInterceptor(new MockOAuth2ClientContext("Fancy"));
+        requestTemplate = new RequestTemplate().method("GET");
+    }
+
+    @Test
+    public void applyAuthorizationHeader() throws Exception {
+        oAuth2FeignRequestInterceptor.apply(requestTemplate);
+        System.out.println(requestTemplate);
+        Map<String, Collection<String>> headers = requestTemplate.headers();
+        Assert.assertTrue("RequestTemplate must have a Authorization header", headers.containsKey("Authorization"));
+        Assert.assertThat("Authorization must have a value of Fancy", headers.get("Authorization"), contains("Bearer Fancy"));
+    }
+}

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.security.oauth2.client.feign;
 
 import feign.RequestTemplate;


### PR DESCRIPTION
This PR adds a new `RequestInterceptor` complementing the existing Feign implementation of a Basic one.
For now it is a simple class to easy use for users to create `RequestInterceptors Beans` and register, since the main goal for this kind of support is the selective interceptors, see [spring-cloud-netflix/issues/288](https://github.com/spring-cloud/spring-cloud-netflix/issues/288).

This fixes gh-56
