### PR TITLE
Allow setting custom AccessTokenProvider on OAuth2FeignRequestInterceptor

### DIFF
--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
@@ -177,4 +177,8 @@ public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
 		oAuth2ClientContext.setAccessToken(obtainableAccessToken);
 		return obtainableAccessToken;
 	}
+
+	public void setAccessTokenProvider(AccessTokenProvider accessTokenProvider) {
+		this.accessTokenProvider = accessTokenProvider;
+	}
 }

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/MockAccessTokenProvider.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/MockAccessTokenProvider.java
@@ -1,0 +1,45 @@
+package org.springframework.cloud.security.oauth2.client.feign;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.resource.UserApprovalRequiredException;
+import org.springframework.security.oauth2.client.resource.UserRedirectRequiredException;
+import org.springframework.security.oauth2.client.token.AccessTokenProvider;
+import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
+
+/**
+ * Mocks the access token provider
+ *
+ * @author Mihhail Verhovtsov
+ */
+public class MockAccessTokenProvider implements AccessTokenProvider {
+
+    private OAuth2AccessToken token;
+
+    public MockAccessTokenProvider(OAuth2AccessToken token) {
+        this.token = token;
+    }
+
+    @Override
+    public OAuth2AccessToken obtainAccessToken(OAuth2ProtectedResourceDetails oAuth2ProtectedResourceDetails, AccessTokenRequest accessTokenRequest) throws UserRedirectRequiredException, UserApprovalRequiredException, AccessDeniedException {
+        return token;
+    }
+
+    @Override
+    public boolean supportsResource(OAuth2ProtectedResourceDetails oAuth2ProtectedResourceDetails) {
+        return true;
+    }
+
+    @Override
+    public OAuth2AccessToken refreshAccessToken(OAuth2ProtectedResourceDetails oAuth2ProtectedResourceDetails, OAuth2RefreshToken oAuth2RefreshToken, AccessTokenRequest accessTokenRequest) throws UserRedirectRequiredException {
+        return null;
+    }
+
+    @Override
+    public boolean supportsRefresh(OAuth2ProtectedResourceDetails oAuth2ProtectedResourceDetails) {
+        return false;
+    }
+
+}

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/MockOAuth2AccessToken.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/MockOAuth2AccessToken.java
@@ -1,0 +1,62 @@
+package org.springframework.cloud.security.oauth2.client.feign;
+
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Mocks the OAuth2 access token
+ *
+ * @author Mihhail Verhovtsov
+ */
+public class MockOAuth2AccessToken implements OAuth2AccessToken {
+
+        private String value;
+
+        public MockOAuth2AccessToken(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public Map<String, Object> getAdditionalInformation() {
+            return null;
+        }
+
+        @Override
+        public Set<String> getScope() {
+            return null;
+        }
+
+        @Override
+        public OAuth2RefreshToken getRefreshToken() {
+            return null;
+        }
+
+        @Override
+        public String getTokenType() {
+            return null;
+        }
+
+        @Override
+        public boolean isExpired() {
+            return false;
+        }
+
+        @Override
+        public Date getExpiration() {
+            return null;
+        }
+
+        @Override
+        public int getExpiresIn() {
+            return 0;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+    }

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptorTests.java
@@ -61,4 +61,11 @@ public class OAuth2FeignRequestInterceptorTests {
 		OAuth2AccessToken oAuth2AccessToken = oAuth2FeignRequestInterceptor.getToken();
 		Assert.assertTrue(oAuth2AccessToken.getValue() + " Must be null", oAuth2AccessToken.getValue() == null);
 	}
+
+	@Test
+	public void configureAccessTokenProvider() {
+		OAuth2AccessToken mockedToken = new MockOAuth2AccessToken("MOCKED_TOKEN");
+		oAuth2FeignRequestInterceptor.setAccessTokenProvider(new MockAccessTokenProvider(mockedToken));
+		Assert.assertEquals("Should return same mocked token instance", mockedToken, oAuth2FeignRequestInterceptor.acquireAccessToken());
+	}
 }


### PR DESCRIPTION
Currently `OAuth2FeignRequestInterceptor` always uses the default `AccessTokenProvider` (a chain of providers actually) and does not allow setting a custom one. The use case for configurable access token provider is to control the way access token is acquired. For example, I would like `AccessTokenProvider` to use Apache HttpClient instead of `URLConnection` in order to enable logging of HTTP requests. FYI, this is possible with `OAuth2RestTemplate` which is sort of analog of Feign client with `OAuth2FeignRequestInterceptor`.