### PR TITLE
Registering tokenRelayRequestInterceptor Fixes GH-123

### DIFF
--- a/spring-cloud-security/pom.xml
+++ b/spring-cloud-security/pom.xml
@@ -82,6 +82,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-jwt</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/AccessTokenContextRelay.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/AccessTokenContextRelay.java
@@ -38,18 +38,12 @@ import org.springframework.security.oauth2.provider.authentication.OAuth2Authent
  */
 public class AccessTokenContextRelay {
 
-	private final OAuth2ClientContext context;
-
-	public AccessTokenContextRelay(OAuth2ClientContext context) {
-		this.context = context;
-	}
-
 	/**
 	 * Attempt to copy an access token from the security context into the oauth2 context.
 	 * 
 	 * @return true if the token was copied
 	 */
-	public boolean copyToken() {
+	public boolean copyToken(OAuth2ClientContext context) {
 		if (context.getAccessToken() == null) {
 			Authentication authentication = SecurityContextHolder.getContext()
 					.getAuthentication();

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfiguration.java
@@ -69,32 +69,34 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 @ConditionalOnWebApplication
 public class ResourceServerTokenRelayAutoConfiguration {
 
-	protected static final String TOKEN_RELAY_REQUEST_INTERCEPTOR = "tokenRelayRequestInterceptor";
-
-	@Bean(name = TOKEN_RELAY_REQUEST_INTERCEPTOR)
-	public HandlerInterceptor tokenRelayRequestInterceptor(
-			final OAuth2ClientContext context) {
-		final AccessTokenContextRelay relay = new AccessTokenContextRelay(context);
-		return new HandlerInterceptorAdapter() {
-			@Override
-			public boolean preHandle(HttpServletRequest request,
-									 HttpServletResponse response, Object handler) throws Exception {
-				relay.copyToken();
-				return true;
-			}
-		};
-	}
-
 	@Configuration
 	public static class ResourceServerTokenRelayRegistrationAutoConfiguration extends WebMvcConfigurerAdapter {
 
 		@Autowired
-		@Qualifier(TOKEN_RELAY_REQUEST_INTERCEPTOR)
 		HandlerInterceptor tokenRelayRequestInterceptor;
+
+		@Bean
+		public AccessTokenContextRelay accessTokenContextRelay() {
+			return new AccessTokenContextRelay();
+		}
+
+		@Autowired
+		OAuth2ClientContext context;
 
 		@Override
 		public void addInterceptors(InterceptorRegistry registry) {
-			registry.addInterceptor(tokenRelayRequestInterceptor);
+			registry.addInterceptor(
+
+					new HandlerInterceptorAdapter() {
+						@Override
+						public boolean preHandle(HttpServletRequest request,
+												 HttpServletResponse response, Object handler) throws Exception {
+							accessTokenContextRelay().copyToken(context);
+							return true;
+						}
+					}
+
+			);
 		}
 
 	}

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfiguration.java
@@ -69,10 +69,9 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 @ConditionalOnWebApplication
 public class ResourceServerTokenRelayAutoConfiguration {
 
-	protected static final String TOKEN_RELAY_REQUEST_INTERCEPTOR = "tokenRelayRequestInterceptor";
+	protected static final String TOKEN_RELAY_REQUEST_INTERCEPTOR = "tokenRelayRequestInterceptors";
 
-	@Bean
-	@Qualifier(TOKEN_RELAY_REQUEST_INTERCEPTOR)
+	@Bean(name = TOKEN_RELAY_REQUEST_INTERCEPTOR)
 	public HandlerInterceptor tokenRelayRequestInterceptor(
 			final OAuth2ClientContext context) {
 		final AccessTokenContextRelay relay = new AccessTokenContextRelay(context);

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfiguration.java
@@ -25,6 +25,8 @@ import java.lang.annotation.Target;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -40,6 +42,8 @@ import org.springframework.security.oauth2.client.OAuth2ClientContext;
 import org.springframework.security.oauth2.config.annotation.web.configuration.OAuth2ClientConfiguration;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfiguration;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 /**
@@ -65,18 +69,35 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 @ConditionalOnWebApplication
 public class ResourceServerTokenRelayAutoConfiguration {
 
+	protected static final String TOKEN_RELAY_REQUEST_INTERCEPTOR = "tokenRelayRequestInterceptor";
+
 	@Bean
+	@Qualifier(TOKEN_RELAY_REQUEST_INTERCEPTOR)
 	public HandlerInterceptor tokenRelayRequestInterceptor(
 			final OAuth2ClientContext context) {
 		final AccessTokenContextRelay relay = new AccessTokenContextRelay(context);
 		return new HandlerInterceptorAdapter() {
 			@Override
 			public boolean preHandle(HttpServletRequest request,
-					HttpServletResponse response, Object handler) throws Exception {
+									 HttpServletResponse response, Object handler) throws Exception {
 				relay.copyToken();
 				return true;
 			}
 		};
+	}
+
+	@Configuration
+	public static class ResourceServerTokenRelayRegistrationAutoConfiguration extends WebMvcConfigurerAdapter {
+
+		@Autowired
+		@Qualifier(TOKEN_RELAY_REQUEST_INTERCEPTOR)
+		HandlerInterceptor tokenRelayRequestInterceptor;
+
+		@Override
+		public void addInterceptors(InterceptorRegistry registry) {
+			registry.addInterceptor(tokenRelayRequestInterceptor);
+		}
+
 	}
 
 	@Target({ ElementType.TYPE, ElementType.METHOD })

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfiguration.java
@@ -67,35 +67,24 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 @ConditionalOnOAuth2ClientInResourceServer
 @ConditionalOnClass(ResourceServerConfiguration.class)
 @ConditionalOnWebApplication
-public class ResourceServerTokenRelayAutoConfiguration {
+public class ResourceServerTokenRelayAutoConfiguration extends WebMvcConfigurerAdapter {
 
-	protected static final String TOKEN_RELAY_REQUEST_INTERCEPTOR = "tokenRelayRequestInterceptors";
+	@Autowired
+	private OAuth2ClientContext context;
 
-	@Bean(name = TOKEN_RELAY_REQUEST_INTERCEPTOR)
-	public HandlerInterceptor tokenRelayRequestInterceptor(
-			final OAuth2ClientContext context) {
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+
 		final AccessTokenContextRelay relay = new AccessTokenContextRelay(context);
-		return new HandlerInterceptorAdapter() {
+
+		registry.addInterceptor(new HandlerInterceptorAdapter() {
 			@Override
 			public boolean preHandle(HttpServletRequest request,
 									 HttpServletResponse response, Object handler) throws Exception {
 				relay.copyToken();
 				return true;
 			}
-		};
-	}
-
-	@Configuration
-	public static class ResourceServerTokenRelayRegistrationAutoConfiguration extends WebMvcConfigurerAdapter {
-
-		@Autowired
-		@Qualifier(TOKEN_RELAY_REQUEST_INTERCEPTOR)
-		HandlerInterceptor tokenRelayRequestInterceptor;
-
-		@Override
-		public void addInterceptors(InterceptorRegistry registry) {
-			registry.addInterceptor(tokenRelayRequestInterceptor);
-		}
+		});
 
 	}
 

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfigurationTests.java
@@ -90,18 +90,6 @@ public class ResourceServerTokenRelayAutoConfigurationTests {
 		server.verify();
 	}
 
-	@Test
-	public void noUserInfo() throws Exception {
-		this.context = new SpringApplicationBuilder(ClientConfiguration.class)
-				.properties("spring.config.name=test", "server.port=0",
-						"security.oauth2.resource.tokenInfoUri:http://example.com",
-						"security.oauth2.client.clientId=foo")
-				.run();
-		HandlerInterceptor interceptor = this.context
-				.getBean("tokenRelayRequestInterceptor", HandlerInterceptor.class);
-		assertNotNull(interceptor);
-	}
-
 	@EnableAutoConfiguration
 	@Configuration
 	@EnableResourceServer

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/tokenrelay/ResourceServerTokenRelayTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/tokenrelay/ResourceServerTokenRelayTests.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.security.oauth2.client.AccessTokenContextRelay;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.*;
@@ -66,8 +67,8 @@ public class ResourceServerTokenRelayTests {
 	@Autowired
 	private MockRestServiceServer mockServerToReceiveRelay;
 
-	@SpyBean(name = "tokenRelayRequestInterceptor")
-	HandlerInterceptor tokenRelayRequestInterceptor;
+	@SpyBean
+	AccessTokenContextRelay accessTokenContextRelay;
 
 	@Test
 	public void tokenRelayJWT() throws Exception {
@@ -84,7 +85,7 @@ public class ResourceServerTokenRelayTests {
 		assertEquals(TEST_RESPONSE, exchange.getBody());
 
 		mockServerToReceiveRelay.verify();
-		verify(tokenRelayRequestInterceptor).preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any(Object.class));
+		verify(accessTokenContextRelay).copyToken(any(OAuth2ClientContext.class));
 	}
 
 	private HttpEntity<String> createAuthorizationHeader() {

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/tokenrelay/ResourceServerTokenRelayTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/tokenrelay/ResourceServerTokenRelayTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.security.oauth2.client.tokenrelay;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.*;
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.junit.Assert.*;
+import static org.springframework.boot.test.context.SpringBootTest.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * @author Peter Szanto (spring@szantocsalad.hu)
+ *
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = {"security.oauth2.resource.jwt.keyValue=secret"})
+public class ResourceServerTokenRelayTests {
+
+	protected static final String TOKEN_VALID_UNTIL_2085 = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjM2NDA2ODU4ODIsInVzZXJfbmFtZSI6InJlYWRlciIsImF1dGhvcml0aWVzIjpbIlJPTEVfUkVBREVSIl0sImp0aSI6ImRkOTAzZGM2LTI0NDctNDViMi04MDZjLTIzZjU3ODVhNGQ4MCIsImNsaWVudF9pZCI6IndlYi1hcHAiLCJzY29wZSI6WyJyZWFkIl19.6hoNtxmN1_o5Ki0D0ae4amSOTRmit3pmaqv-z1-Qk4Y";
+	protected static final String AUTH_HEADER_TO_BE_RELAYED = "bearer " + TOKEN_VALID_UNTIL_2085;
+	protected static final String TEST_RESPONSE = "[\"test response\"]";
+
+	@Autowired
+	private TestRestTemplate testRestTemplate;
+
+	@Autowired
+	private MockRestServiceServer mockServerToReceiveRelay;
+
+	@Test
+	public void tokenRelayJWT() throws Exception {
+
+		mockServerToReceiveRelay
+			.expect(requestTo("http://example.com/test"))
+			.andExpect(header("authorization", AUTH_HEADER_TO_BE_RELAYED))
+			.andRespond(withSuccess(TEST_RESPONSE, MediaType.APPLICATION_JSON));
+
+		HttpEntity<String> authorizationHeader = createAuthorizationHeader();
+		ResponseEntity<String> exchange = testRestTemplate.exchange("/token-relay", HttpMethod.GET, authorizationHeader, String.class);
+
+		assertEquals(HttpStatus.OK.value(), exchange.getStatusCodeValue());
+		assertEquals(TEST_RESPONSE, exchange.getBody());
+
+		mockServerToReceiveRelay.verify();
+	}
+
+	private HttpEntity<String> createAuthorizationHeader() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", AUTH_HEADER_TO_BE_RELAYED);
+		return new HttpEntity<String>("parameters", headers);
+
+	}
+
+	@SpringBootApplication
+	@TestConfiguration
+	@EnableResourceServer
+	@ComponentScan(basePackageClasses = TokenRelayTestController.class)
+	@EnableOAuth2Client
+	protected static class ClientConfiguration {
+
+		@Bean
+		public OAuth2RestTemplate oauth2RestTemplate(
+				OAuth2ProtectedResourceDetails resource,
+				OAuth2ClientContext oauth2Context) {
+			return new OAuth2RestTemplate(resource, oauth2Context);
+
+		}
+
+		@Bean
+		public MockRestServiceServer mockRestServiceServer(OAuth2RestTemplate template) {
+			return MockRestServiceServer.createServer(template);
+		}
+
+	}
+
+	@RestController
+	@TestComponent
+	protected static class TokenRelayTestController {
+
+		@Autowired
+		OAuth2RestTemplate oAuth2RestTemplate;
+
+		@GetMapping("/token-relay")
+		public String getAccount() {
+
+			return oAuth2RestTemplate.getForEntity("http://example.com/test", String.class).getBody();
+
+		}
+	}
+}

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/tokenrelay/ResourceServerTokenRelayTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/tokenrelay/ResourceServerTokenRelayTests.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -36,8 +37,12 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.web.servlet.HandlerInterceptor;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
 import static org.springframework.boot.test.context.SpringBootTest.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -61,6 +66,9 @@ public class ResourceServerTokenRelayTests {
 	@Autowired
 	private MockRestServiceServer mockServerToReceiveRelay;
 
+	@SpyBean(name = "tokenRelayRequestInterceptor")
+	HandlerInterceptor tokenRelayRequestInterceptor;
+
 	@Test
 	public void tokenRelayJWT() throws Exception {
 
@@ -76,6 +84,7 @@ public class ResourceServerTokenRelayTests {
 		assertEquals(TEST_RESPONSE, exchange.getBody());
 
 		mockServerToReceiveRelay.verify();
+		verify(tokenRelayRequestInterceptor).preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any(Object.class));
 	}
 
 	private HttpEntity<String> createAuthorizationHeader() {
@@ -115,7 +124,7 @@ public class ResourceServerTokenRelayTests {
 		OAuth2RestTemplate oAuth2RestTemplate;
 
 		@GetMapping("/token-relay")
-		public String getAccount() {
+		public String callAnotherService() {
 
 			return oAuth2RestTemplate.getForEntity("http://example.com/test", String.class).getBody();
 


### PR DESCRIPTION
ResourceServerTokenRelayAutoConfiguration creates a @Bean of HandlerInterceptor (tokenRelayRequestInterceptor) but it is never registered into the Spring MVC InterceptorRegistry, therefore never runs. I believe this approach would work with a Zuul filter but MVC filters have to be explicitly registered. Without this filter token Relay of JWT tokens does not work