### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/OAuth2ClientAutoConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/OAuth2ClientAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/OAuth2LoadBalancerClientAutoConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/OAuth2LoadBalancerClientAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/environment/VcapServiceCredentialsListener.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/environment/VcapServiceCredentialsListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/proxy/OAuth2ProxyAutoConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/proxy/OAuth2ProxyAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/proxy/ProxyAuthenticationProperties.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/proxy/ProxyAuthenticationProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/EnableOAuth2Resource.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/EnableOAuth2Resource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/JwtAccessTokenConverterConfigurer.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/JwtAccessTokenConverterConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/OAuth2ResourceConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/OAuth2ResourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/ResourceServerProperties.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/ResourceServerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/SpringSocialTokenServices.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/SpringSocialTokenServices.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/UserInfoRestTemplateCustomizer.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/UserInfoRestTemplateCustomizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/UserInfoTokenServices.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/resource/UserInfoTokenServices.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/EnableOAuth2Sso.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/EnableOAuth2Sso.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfiguration.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfigurer.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfigurerAdapter.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoProperties.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/environment/VcapServiceCredentialsListenerTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/environment/VcapServiceCredentialsListenerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/proxy/OAuth2TokenRelayFilterTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/proxy/OAuth2TokenRelayFilterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/BasicOAuth2ResourceConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/BasicOAuth2ResourceConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/JwtTokenServicesConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/JwtTokenServicesConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/ResourceServerPropertiesTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/ResourceServerPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/UserInfoTokenServicesTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/UserInfoTokenServicesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/BasicOAuth2SsoConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/BasicOAuth2SsoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoPropertiesTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 28 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).