### PR TITLE
URL Cleanup

### DIFF
--- a/1.2.x/spring-cloud-security.xml
+++ b/1.2.x/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -168,7 +168,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/2.0.x/spring-cloud-security.xml
+++ b/2.0.x/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -168,7 +168,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/2.1.x/spring-cloud-security.xml
+++ b/2.1.x/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -226,7 +226,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-security.xml
+++ b/spring-cloud-security.xml
@@ -138,7 +138,7 @@ class Application {
 <note>
 <simpara>All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-<link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
+<link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot user guide</link>.</simpara>
 </note>
 </section>
 <section xml:id="_token_relay">
@@ -226,7 +226,7 @@ Security and Spring Boot.)</simpara>
 <section xml:id="_client_token_relay_in_zuul_proxy">
 <title>Client Token Relay in Zuul Proxy</title>
 <simpara>If your app also has a
-<link xl:href="http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
+<link xl:href="https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy">Spring
 Cloud Zuul</link> embedded reverse proxy (using <literal>@EnableZuulProxy</literal>) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://cloud.spring.io/spring-cloud.html (404) with 4 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud.html ([https](https://cloud.spring.io/spring-cloud.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 4 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://localhost:9000 with 4 occurrences
* http://www.w3.org/1999/xlink with 4 occurrences
* http://www.w3.org/2000/svg with 1 occurrences