### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ exchange.
 === Basic Compile and Test
 
 To build the source you will need to install
-http://maven.apache.org/run-maven/index.html[Apache Maven] v3.0.6 or above and JDK {jdkversion}.
+https://maven.apache.org/run-maven/index.html[Apache Maven] v3.0.6 or above and JDK {jdkversion}.
 
 Spring Cloud uses Maven for most build-related activities, and you
 should be able to get off the ground quite quickly by cloning the
@@ -47,7 +47,7 @@ credentials and you already have those.
 If you need mongo, rabbit or redis, see the README in the https://github.com/spring-cloud-samples/scripts[scripts
 demo repository] for
 instructions. For example consider using the "fig.yml" with
-http://www.fig.sh/[Fig] to run them in Docker containers.
+https://www.fig.sh/[Fig] to run them in Docker containers.
 
 === Documentation
 
@@ -86,7 +86,7 @@ added after the original pull request but before a merge.
   the ``Importing into eclipse'' instructions below you should get project specific
   formatting automatically. You can also import formatter settings using the
   `eclipse-code-formatter.xml` file from the `eclipse` folder. If using IntelliJ, you can
-  use the http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter Plugin]
+  use the https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter Plugin]
   to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -102,13 +102,13 @@ added after the original pull request but before a merge.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -127,7 +127,7 @@ from the `file` menu.
 ==== Adding Project Lombok Agent
 
 Spring Cloud uses [Project
-Lombok](http://projectlombok.org/features/index.html) to generate
+Lombok](https://projectlombok.org/features/index.html) to generate
 getters and setters etc. Compiling from the command line this
 shouldn't cause any problems, but in an IDE you need to add an agent
 to the JVM. Full instructions can be found in the Lombok website. The
@@ -171,7 +171,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -184,6 +184,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/docs/src/main/asciidoc/spring-cloud-security.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-security.adoc
@@ -251,7 +251,7 @@ Server.
 ==== Client Token Relay
 
 If your app has a
-http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy[Spring
+https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy[Spring
 Cloud Zuul] embedded reverse proxy (using `@EnableZuulProxy`) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like this:

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/environment/VcapServiceCredentialsListenerTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/environment/VcapServiceCredentialsListenerTests.java
@@ -49,27 +49,27 @@ public class VcapServiceCredentialsListenerTests {
 
 	@Test
 	public void addTokenUri() {
-		EnvironmentTestUtils.addEnvironment(environment, "vcap.services.sso.credentials.tokenUri:http://example.com");
+		EnvironmentTestUtils.addEnvironment(environment, "vcap.services.sso.credentials.tokenUri:https://example.com");
 		listener.onApplicationEvent(new ApplicationEnvironmentPreparedEvent(
 				new SpringApplication(), null, environment));
-		assertEquals("http://example.com", environment.resolvePlaceholders("${spring.oauth2.client.accessTokenUri}"));
+		assertEquals("https://example.com", environment.resolvePlaceholders("${spring.oauth2.client.accessTokenUri}"));
 	}
 
 	@Test
 	public void addUserInfoUri() {
-		EnvironmentTestUtils.addEnvironment(environment, "vcap.services.sso.credentials.userInfoUri:http://example.com");
+		EnvironmentTestUtils.addEnvironment(environment, "vcap.services.sso.credentials.userInfoUri:https://example.com");
 		listener.onApplicationEvent(new ApplicationEnvironmentPreparedEvent(
 				new SpringApplication(), null, environment));
-		assertEquals("http://example.com", environment.resolvePlaceholders("${spring.oauth2.resource.userInfoUri}"));
+		assertEquals("https://example.com", environment.resolvePlaceholders("${spring.oauth2.resource.userInfoUri}"));
 	}
 
 	@Test
 	public void addServiceId() {
-		EnvironmentTestUtils.addEnvironment(environment, "vcap.services.my.credentials.tokenUri:http://example.com",
+		EnvironmentTestUtils.addEnvironment(environment, "vcap.services.my.credentials.tokenUri:https://example.com",
 				"spring.oauth2.sso.serviceId:my");
 		listener.onApplicationEvent(new ApplicationEnvironmentPreparedEvent(
 				new SpringApplication(), null, environment));
-		assertEquals("http://example.com", environment.resolvePlaceholders("${spring.oauth2.client.accessTokenUri}"));
+		assertEquals("https://example.com", environment.resolvePlaceholders("${spring.oauth2.client.accessTokenUri}"));
 	}
 
 }

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/BasicOAuth2ResourceConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/BasicOAuth2ResourceConfigurationTests.java
@@ -52,7 +52,7 @@ import org.springframework.web.context.WebApplicationContext;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = TestConfiguration.class)
 @WebAppConfiguration
-@TestPropertySource(properties = { "debug:true", "spring.oauth2.resource.userInfoUri=http://start.spring.io" })
+@TestPropertySource(properties = { "debug:true", "spring.oauth2.resource.userInfoUri=https://start.spring.io" })
 public class BasicOAuth2ResourceConfigurationTests {
 
 	@Autowired

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/ResourceServerPropertiesTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/ResourceServerPropertiesTests.java
@@ -33,7 +33,7 @@ public class ResourceServerPropertiesTests {
 
 	@Test
 	public void json() throws Exception {
-		properties.getJwt().setKeyUri("http://example.com/token_key");
+		properties.getJwt().setKeyUri("https://example.com/token_key");
 		ObjectMapper mapper = new ObjectMapper();
 		String json = mapper.writeValueAsString(properties);
 		@SuppressWarnings("unchecked")
@@ -45,7 +45,7 @@ public class ResourceServerPropertiesTests {
 
 	@Test
 	public void tokenKeyDerived() throws Exception {
-		properties.setUserInfoUri("http://example.com/userinfo");
+		properties.setUserInfoUri("https://example.com/userinfo");
 		assertNotNull("Wrong properties: " + properties, properties.getJwt().getKeyUri());
 	}
 

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
@@ -77,7 +77,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void useRemoteTokenServices() {
 		EnvironmentTestUtils.addEnvironment(environment,
-				"spring.oauth2.resource.tokenInfoUri:http://example.com");
+				"spring.oauth2.resource.tokenInfoUri:https://example.com");
 		context = new SpringApplicationBuilder(ResourceConfiguration.class)
 				.environment(environment).web(false).run();
 		RemoteTokenServices services = context.getBean(RemoteTokenServices.class);
@@ -87,7 +87,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void switchToUserInfo() {
 		EnvironmentTestUtils.addEnvironment(environment,
-				"spring.oauth2.resource.userInfoUri:http://example.com");
+				"spring.oauth2.resource.userInfoUri:https://example.com");
 		context = new SpringApplicationBuilder(ResourceConfiguration.class)
 				.environment(environment).web(false).run();
 		UserInfoTokenServices services = context.getBean(UserInfoTokenServices.class);
@@ -98,7 +98,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 	public void userInfoDoesNotRequireClient() {
 		EnvironmentTestUtils.addEnvironment(environment,
 				"spring.oauth2.client.clientId:",
-				"spring.oauth2.resource.userInfoUri:http://example.com");
+				"spring.oauth2.resource.userInfoUri:https://example.com");
 		context = new SpringApplicationBuilder(ResourceConfiguration.class)
 				.environment(environment).web(false).run();
 		UserInfoTokenServices services = context.getBean(UserInfoTokenServices.class);
@@ -109,8 +109,8 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void preferUserInfo() {
 		EnvironmentTestUtils.addEnvironment(environment,
-				"spring.oauth2.resource.userInfoUri:http://example.com",
-				"spring.oauth2.resource.tokenInfoUri:http://example.com",
+				"spring.oauth2.resource.userInfoUri:https://example.com",
+				"spring.oauth2.resource.tokenInfoUri:https://example.com",
 				"spring.oauth2.resource.preferTokenInfo:false");
 		context = new SpringApplicationBuilder(ResourceConfiguration.class)
 				.environment(environment).web(false).run();
@@ -153,7 +153,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void springSocialUserInfo() {
 		EnvironmentTestUtils.addEnvironment(environment,
-				"spring.oauth2.resource.userInfoUri:http://example.com",
+				"spring.oauth2.resource.userInfoUri:https://example.com",
 				"spring.social.facebook.app-id=foo",
 				"spring.social.facebook.app-secret=bar");
 		context = new SpringApplicationBuilder(SocialResourceConfiguration.class)

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/UserInfoTokenServicesTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/resource/UserInfoTokenServicesTests.java
@@ -41,7 +41,7 @@ import org.springframework.security.oauth2.common.OAuth2AccessToken;
 public class UserInfoTokenServicesTests {
 
 	private UserInfoTokenServices services = new UserInfoTokenServices(
-			"http://example.com", "foo");
+			"https://example.com", "foo");
 	private BaseOAuth2ProtectedResourceDetails resource = new BaseOAuth2ProtectedResourceDetails();
 	private OAuth2RestOperations template = Mockito.mock(OAuth2RestOperations.class);
 	private OAuth2ClientContext clientContext = Mockito.mock(OAuth2ClientContext.class);
@@ -79,7 +79,7 @@ public class UserInfoTokenServicesTests {
 
 	@Test
 	public void noClientId() {
-		services = new UserInfoTokenServices("http://example.com", null);
+		services = new UserInfoTokenServices("https://example.com", null);
 		resource.setClientId(null);
 		services.setRestTemplate(template);
 		assertEquals("unknown", services.loadAuthentication("FOO").getName());
@@ -88,9 +88,9 @@ public class UserInfoTokenServicesTests {
 	@Test
 	public void noAccessToken() {
 		Mockito.when(template.getAccessToken()).thenThrow(
-				new UserRedirectRequiredException("http://another.com", Collections
+				new UserRedirectRequiredException("https://another.com", Collections
 						.<String, String> emptyMap()));
-		services = new UserInfoTokenServices("http://example.com", null);
+		services = new UserInfoTokenServices("https://example.com", null);
 		resource.setClientId(null);
 		services.setRestTemplate(template);
 		assertEquals("unknown", services.loadAuthentication("FOO").getName());

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/BasicOAuth2SsoConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/BasicOAuth2SsoConfigurationTests.java
@@ -48,8 +48,8 @@ import org.springframework.web.context.WebApplicationContext;
 @WebAppConfiguration
 @TestPropertySource(properties = { "spring.oauth2.client.clientId=client",
 		"spring.oauth2.client.clientSecret=secret",
-		"spring.oauth2.client.authorizationUri=http://example.com/oauth/authorize",
-		"spring.oauth2.client.tokenUri=http://example.com/oauth/token",
+		"spring.oauth2.client.authorizationUri=https://example.com/oauth/authorize",
+		"spring.oauth2.client.tokenUri=https://example.com/oauth/token",
 		"spring.oauth2.resource.jwt.keyValue=SSSSHHH" })
 public class BasicOAuth2SsoConfigurationTests {
 

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
@@ -51,8 +51,8 @@ import org.springframework.web.context.WebApplicationContext;
 @WebAppConfiguration
 @TestPropertySource(properties = { "spring.oauth2.client.clientId=client",
 		"spring.oauth2.client.clientSecret=secret",
-		"spring.oauth2.client.authorizationUri=http://example.com/oauth/authorize",
-		"spring.oauth2.client.tokenUri=http://example.com/oauth/token",
+		"spring.oauth2.client.authorizationUri=https://example.com/oauth/authorize",
+		"spring.oauth2.client.tokenUri=https://example.com/oauth/token",
 		"spring.oauth2.resource.jwt.keyValue=SSSSHHH" })
 public class CustomOAuth2SsoConfigurationTests {
 

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoPropertiesTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/sso/OAuth2SsoPropertiesTests.java
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class OAuth2SsoPropertiesTests {
 	
-	private OAuth2SsoProperties properties = new OAuth2SsoProperties("http://example.com");
+	private OAuth2SsoProperties properties = new OAuth2SsoProperties("https://example.com");
 
 	@Test
 	public void defaultRoot() {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://cloud.spring.io/spring-cloud.html (404) with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud.html ([https](https://cloud.spring.io/spring-cloud.html) result 404).
* [ ] http://example.com/oauth/authorize (404) with 2 occurrences migrated to:  
  https://example.com/oauth/authorize ([https](https://example.com/oauth/authorize) result 404).
* [ ] http://example.com/oauth/token (404) with 2 occurrences migrated to:  
  https://example.com/oauth/token ([https](https://example.com/oauth/token) result 404).
* [ ] http://example.com/token_key (404) with 1 occurrences migrated to:  
  https://example.com/token_key ([https](https://example.com/token_key) result 404).
* [ ] http://example.com/userinfo (404) with 1 occurrences migrated to:  
  https://example.com/userinfo ([https](https://example.com/userinfo) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://another.com with 1 occurrences migrated to:  
  https://another.com ([https](https://another.com) result 200).
* [ ] http://example.com with 16 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://maven.apache.org/run-maven/index.html with 1 occurrences migrated to:  
  https://maven.apache.org/run-maven/index.html ([https](https://maven.apache.org/run-maven/index.html) result 200).
* [ ] http://start.spring.io with 1 occurrences migrated to:  
  https://start.spring.io ([https](https://start.spring.io) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://www.fig.sh/ with 1 occurrences migrated to:  
  https://www.fig.sh/ ([https](https://www.fig.sh/) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 2 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://projectlombok.org/features/index.html with 1 occurrences migrated to:  
  https://projectlombok.org/features/index.html ([https](https://projectlombok.org/features/index.html) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost/login with 2 occurrences