### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,7 +84,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -106,13 +106,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -168,7 +168,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -181,6 +181,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/docs/src/main/asciidoc/spring-cloud-security.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-security.adoc
@@ -18,7 +18,7 @@ include::quickstart.adoc[]
 
 NOTE: All of the OAuth2 SSO and resource server features moved to Spring Boot
 in version 1.3. You can find documentation in the
-http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/[Spring Boot user guide].
+https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/[Spring Boot user guide].
 
 === Token Relay
 
@@ -48,7 +48,7 @@ NOTE: Spring Boot (1.4.1) does not create an
 ==== Client Token Relay in Zuul Proxy
 
 If your app also has a
-http://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy[Spring
+https://cloud.spring.io/spring-cloud.html#netflix-zuul-reverse-proxy[Spring
 Cloud Zuul] embedded reverse proxy (using `@EnableZuulProxy`) then you
 can ask it to forward OAuth2 access tokens downstream to the services
 it is proxying. Thus the SSO app above can be enhanced simply like

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/OAuth2LoadBalancerClientAutoConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/OAuth2LoadBalancerClientAutoConfigurationTests.java
@@ -59,7 +59,7 @@ public class OAuth2LoadBalancerClientAutoConfigurationTests {
 	public void clientNotConfigured() {
 		this.context = new SpringApplicationBuilder(NoClientConfiguration.class)
 				.properties("spring.config.name=test", "server.port=0",
-						"security.oauth2.resource.userInfoUri:http://example.com")
+						"security.oauth2.resource.userInfoUri:https://example.com")
 				.run();
 		assertFalse(this.context.containsBean("loadBalancedOauth2RestTemplate"));
 	}
@@ -68,7 +68,7 @@ public class OAuth2LoadBalancerClientAutoConfigurationTests {
 	public void clientConfigured() throws Exception {
 		this.context = new SpringApplicationBuilder(ClientConfiguration.class)
 				.properties("spring.config.name=test", "server.port=0",
-						"security.oauth2.resource.userInfoUri:http://example.com",
+						"security.oauth2.resource.userInfoUri:https://example.com",
 						"security.oauth2.client.clientId=foo")
 				.run();
 		OAuth2RestTemplate template = this.context

--- a/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfigurationTests.java
+++ b/spring-cloud-security/src/test/java/org/springframework/cloud/security/oauth2/client/ResourceServerTokenRelayAutoConfigurationTests.java
@@ -63,7 +63,7 @@ public class ResourceServerTokenRelayAutoConfigurationTests {
 	public void clientNotConfigured() {
 		this.context = new SpringApplicationBuilder(NoClientConfiguration.class)
 				.properties("spring.config.name=test", "server.port=0",
-						"security.oauth2.resource.userInfoUri:http://example.com")
+						"security.oauth2.resource.userInfoUri:https://example.com")
 				.run();
 		assertFalse(this.context.containsBean("loadBalancedOauth2RestTemplate"));
 	}
@@ -72,7 +72,7 @@ public class ResourceServerTokenRelayAutoConfigurationTests {
 	public void clientConfigured() throws Exception {
 		this.context = new SpringApplicationBuilder(ClientConfiguration.class)
 				.properties("spring.config.name=test", "server.port=0",
-						"security.oauth2.resource.userInfoUri:http://example.com",
+						"security.oauth2.resource.userInfoUri:https://example.com",
 						"security.oauth2.client.clientId=foo")
 				.run();
 		RequestContextHolder.setRequestAttributes(
@@ -83,7 +83,7 @@ public class ResourceServerTokenRelayAutoConfigurationTests {
 		OAuth2RestTemplate template = (OAuth2RestTemplate) ReflectionTestUtils
 				.getField(services, "restTemplate");
 		MockRestServiceServer server = MockRestServiceServer.createServer(template);
-		server.expect(requestTo("http://example.com"))
+		server.expect(requestTo("https://example.com"))
 				.andRespond(withSuccess("{\"id\":\"user\"}", MediaType.APPLICATION_JSON));
 		services.loadAuthentication("FOO");
 		assertEquals("FOO", client.getAccessToken().getValue());
@@ -94,7 +94,7 @@ public class ResourceServerTokenRelayAutoConfigurationTests {
 	public void noUserInfo() throws Exception {
 		this.context = new SpringApplicationBuilder(ClientConfiguration.class)
 				.properties("spring.config.name=test", "server.port=0",
-						"security.oauth2.resource.tokenInfoUri:http://example.com",
+						"security.oauth2.resource.tokenInfoUri:https://example.com",
 						"security.oauth2.client.clientId=foo")
 				.run();
 		HandlerInterceptor interceptor = this.context


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://cloud.spring.io/spring-cloud.html (404) with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud.html ([https](https://cloud.spring.io/spring-cloud.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://example.com with 6 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://nosuchservice with 1 occurrences