### PR TITLE
Only apply the Authorization header once

### DIFF
--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2015 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.springframework.security.oauth2.common.OAuth2AccessToken;
  * construct a new header on the request before it is made by Feign.
  *
  * @author Joao Pedro Evangelista
+ * @author Tim Ysewyn
  */
 public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
 
@@ -101,6 +102,7 @@ public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
 	 */
 	@Override
 	public void apply(RequestTemplate template) {
+		template.header(header);
 		template.header(header, extract(tokenType));
 	}
 

--- a/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
+++ b/spring-cloud-security/src/main/java/org/springframework/cloud/security/oauth2/client/feign/OAuth2FeignRequestInterceptor.java
@@ -102,7 +102,7 @@ public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
 	 */
 	@Override
 	public void apply(RequestTemplate template) {
-		template.header(header);
+		template.header(header); // Clears out the header, no "clear" method available.
 		template.header(header, extract(tokenType));
 	}
 


### PR DESCRIPTION
When the first idempotent call fails, the retry mechanism kicks in and the token has expired in the meantime the newly requested would be added as a second entry for the Authorization header
Fixes gh-212